### PR TITLE
Update basics.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/basics.adoc
+++ b/documentation/modules/ROOT/pages/basics.adoc
@@ -73,7 +73,7 @@ Minikube::
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-helm install faq-db --set global.postgresql.auth.username=faq-default,global.postgresql.auth.password=postgres,global.postgresql.auth.database=faq,primary.persistence.enabled=false,\
+helm install faq-db --set global.postgresql.auth.username=faq-default,global.postgresql.auth.password=postgres,global.postgresql.auth.database=faq,primary.persistence.enabled=false \
 --version 12.1.2  bitnami/postgresql
 ----
 --	


### PR DESCRIPTION
Extra comma in set argument, doesn't allow to install the chart


Helm Version:
```
➜  ~ helm version 2>/dev/null
version.BuildInfo{Version:"v3.10.1", GitCommit:"9f88ccb6aee40b9a0535fcc7efea6055e1ef72c9", GitTreeState:"clean", GoVersion:"go1.18.7"}
```

**Error:**
```
➜  ~ helm install faq-db --set global.postgresql.auth.username=faq-default,global.postgresql.auth.password=postgres,global.postgresql.auth.database=faq,primary.persistence.enabled=false,\
--version 12.1.2  bitnami/postgresql
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments: bitnami/postgresql
```